### PR TITLE
Fixes some problems I've found using ffi.el

### DIFF
--- a/ffi.el
+++ b/ffi.el
@@ -99,7 +99,7 @@ SLOT-NAME is a symbol and TYPE is an FFI type descriptor."
   ;; This is a hack until libffi gives us direct support.
   (let ((type-description
 	 (apply #'ffi--define-struct
-                (make-list (eval length) type))))
+                (make-list (eval length) (symbol-value type)))))
     `(defvar ,name ,type-description ,docstring)))
 
 (defsubst ffi-aref (array type index)

--- a/ffi.el
+++ b/ffi.el
@@ -98,8 +98,8 @@ SLOT-NAME is a symbol and TYPE is an FFI type descriptor."
 (defmacro define-ffi-array (name type length &optional docstring)
   ;; This is a hack until libffi gives us direct support.
   (let ((type-description
-	 (apply #'ffi--define-struct (make-list (eval length)
-						(symbol-name type)))))
+	 (apply #'ffi--define-struct
+                (make-list (eval length) type))))
     `(defvar ,name ,type-description ,docstring)))
 
 (defsubst ffi-aref (array type index)
@@ -109,7 +109,7 @@ SLOT-NAME is a symbol and TYPE is an FFI type descriptor."
   (declare (indent defun))
   `(let ((,(car binding) (ffi-allocate ,@(cdr binding))))
      (unwind-protect
-	 ,@body
+         (progn ,@body)
        (ffi-free ,(car binding)))))
 
 (defmacro with-ffi-temporaries (bindings &rest body)
@@ -126,7 +126,7 @@ SLOT-NAME is a symbol and TYPE is an FFI type descriptor."
   (declare (indent defun))
   `(let ((,(car binding) (ffi-make-c-string ,@(cdr binding))))
      (unwind-protect
-	 ,@body
+         (progn ,@body)
        (ffi-free ,(car binding)))))
 
 (defmacro with-ffi-strings (bindings &rest body)

--- a/test.el
+++ b/test.el
@@ -97,3 +97,16 @@
   (should (eq (test-not t) nil))
   (should (eq (test-not 0) nil))
   (should (eq (test-not "hi") nil)))
+
+(defconst test-user-defined-char :char)
+
+(ert-deftest ffi-array ()
+  (should (eq (define-ffi-array arr1 :char 1024) 'arr1))
+  (should (eq (define-ffi-array arr2 test-user-defined-char 1024) 'arr2)))
+
+(ert-deftest ffi-with-ffi-multi-stat ()
+  (should (eq (with-ffi-temporary (a :int) 1 2 3) 3))
+  (should (eq (with-ffi-temporaries ((a :int) (b :int)) 1 2 3) 3))
+  (should (eq (with-ffi-string (a "test") 1 2 3) 3))
+  (should (eq (with-ffi-strings ((a "s1") (b "s2")) 1 2 3) 3)))
+


### PR DESCRIPTION
[fix] define-ffi-struct: make it work for definitions like

    (define-ffi-struct PointInfo
      (x :type :double)
      (y :type :double))

[fix] with-ffi-string/with-ffi-temporary: execute body under `progn',
      so multiexpression body won't screw things up