### PR TITLE
added a (crashing) test that calls an ffi-function from a callback

### DIFF
--- a/test.el
+++ b/test.el
@@ -34,6 +34,15 @@
 (ert-deftest ffi-add ()
   (should (eq (test-add 23 -23) 0)))
 
+(defun callback-with-ffi-add-call (arg)
+	(test-add 1 arg)
+	)
+
+(ert-deftest ffi-call-callback-with-ffi-add-call ()
+  (let* ((cif (ffi--prep-cif :int [:int]))
+	 (pointer-to-callback (ffi-make-closure cif #'callback-with-ffi-add-call)))
+    (should (eq (test-call-callback pointer-to-callback) "hello"))))
+
 (ert-deftest ffi-struct-layout ()
   (let ((struct-type (ffi--define-struct :int)))
     (should (eq (ffi--type-size struct-type)


### PR DESCRIPTION
I've run into this problem (when building a libclang-based emacs plugin): when calling a function from a callback, the (global) environment pointer is nulled out after the function call (but before finishing the callback). This causes an assertion to fail and crashes emacs.

I see that this is tricky to handle due to the poorly designed emacs runtime (see https://github.com/aaptel/emacs-dynamic-module/issues/41). I have some ideas how to fix/hack it (e.g., a map of function calls to environment objects) and would be willing to help. I felt that this starts with contributing a test case :-).