### PR TITLE
Perform work in macro calling environment

### DIFF
--- a/ffi.el
+++ b/ffi.el
@@ -7,11 +7,8 @@
 (gv-define-simple-setter ffi--mem-ref ffi--mem-set t)
 
 (defmacro define-ffi-library (symbol name)
-  (let ((library (cl-gensym)))
-    (set library nil)
-    `(defun ,symbol ()
-       (or ,library
-	   (setq ,library (ffi--dlopen ,name))))))
+  `(defconst ,(intern (concat "ffi-" (symbol-name symbol)))
+     (ffi--dlopen ,name)))
 
 (defmacro define-ffi-function (name c-name return-type arg-types library)
   (let* (


### PR DESCRIPTION
Call `ffi--prep-cif` and the `definer-function` of `ffi--struct-union-helper` in the calling environment of the macros not during the macro expansion. This is so that compiling programs that use `define-ffi-function`, `define-ffi-struct`, etc. work. See https://www.gnu.org/software/emacs/manual/html_node/elisp/Wrong-Time.html#Wrong-Time.

Also instead of defining the library as a function in `define-ffi-library` I thought it would be better to mark it as a constant since a library is only every opened once. Note that `define-ffi-library` also had the problem of performing work when expanding the macro as described above.

Finally, I changed the expansion of `define-ffi-function` based on the expansion of `lexical-let`. In the previous implementation, a variable which holds the `ffi` function object returned by `ffi--dlsym` was using the global `obarray` symbol table (this holds all the variable and function symbols visible to emacs. This means that `describe-variable` and the like would show the variable holding the `ffi` function object when really this is only ever used inside the function returned by `define-ffi-function`. In this re-implementation, the variables which hold the `cif` and the `ffi` function objects are not added to the global `obarray` and are only visible to the function returned by `define-ffi-function`.

