### PR TITLE
Improve how libraries are located and various cleanup

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,2 @@
+((emacs-lisp-mode
+  (indent-tabs-mode . nil)))

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,43 @@
+name: 'Compile'
+permissions: {}
+on: [push, pull_request]
+jobs:
+  main:
+    name: 'Compile'
+#   runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    needs: matrix
+    strategy:
+      fail-fast: false
+      matrix:
+#       os: [ubuntu-latest, macos-latest, windows-latest]
+        emacs:
+          - 28.1
+          - 29.4
+          - release-snapshot
+          - snapshot
+    steps:
+      - name: 'Install Emacs'
+        uses: purcell/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs }}
+      - name: 'Install dependencies'
+        run: |
+          sudo apt-get install build-essential libffi-dev libltdl-dev
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: 'Compile module'
+        run: |
+          make module
+      - name: 'Compile lisp'
+        run: |
+          make lisp
+      - name: 'Compile lisp (byte-compile-error-on-warn)'
+#       if: ${{ vars.byte_compile_error_on_warn != 'nil' }}
+        run: |
+          make EMACS_ARGS="--eval '(progn \
+          (setq byte-compile-error-on-warn t) \
+          ${{ vars.compile_error_settings }})'" redo-lisp
+#     - name: 'Test'

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
+config.mk
 ffi-module.o
 ffi-module.so
 test.o

--- a/Makefile
+++ b/Makefile
@@ -1,53 +1,88 @@
-# Makefile for FFI module.
-
-# This is is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-
-# This is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-
-# You should have received a copy of the GNU General Public License
-# along with this.  If not, see <https://www.gnu.org/licenses/>.
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 -include config.mk
 
-# Where your dynamic-module-enabled Emacs build lies.
-EMACS_BUILDDIR ?= /home/tromey/Emacs/emacs
+# Set this to debug make test.
+# GDB = gdb --args
 
-LDFLAGS = -shared
-LIBS = -lffi -lltdl
-CFLAGS += -g3 -Og -finline-small-functions -shared -fPIC \
+# FIXME Emacs (what release?) now installs the necessary headers
+# so this shouldn't be required anymore.
+# EMACS_BUILDDIR ?= /home/tromey/Emacs/emacs
+EMACS_BUILDDIR ?= /home/jonas/src/emacs/emacs/master
+
+PKG = ffi
+
+ELS   = ffi.el
+ELS  += test.el
+ELCS  = $(ELS:.el=.elc)
+
+EMACS      ?= emacs
+EMACS_ARGS ?=
+LOAD_PATH   = -L .
+
+LDFLAGS  = -shared
+LIBS     = -lffi -lltdl
+CFLAGS  += -g3 -Og -finline-small-functions -shared -fPIC \
   -I$(EMACS_BUILDDIR)/src/ -I$(EMACS_BUILDDIR)/lib/
 
-# Set this to debug make check.
-#GDB = gdb --args
+all: module test-module lisp
 
-all: module test-module
+help:
+	$(info make all          - build module and lisp)
+	$(info make redo         - re-build module and lisp)
+	$(info make module       - build module)
+	$(info make test-module  - build test module)
+	$(info make lisp         - build lisp and autoloads)
+	$(info make test         - run tests)
+	$(info make clean        - remove generated files)
+	@printf "\n"
+
+redo: clean all
 
 module: ffi-module.so
+
+test-module: test.so
+
+lisp: $(ELCS) loaddefs
+
+test: ffi-module.so test.so $(ELCS)
+	LD_LIBRARY_PATH=`pwd`:$$LD_LIBRARY_PATH; \
+	  export LD_LIBRARY_PATH; \
+	$(GDB) $(EMACS_BUILDDIR)/src/emacs -batch -L `pwd` -l ert -l test.el \
+	  -f ert-run-tests-batch-and-exit
+
+clean:
+	@printf " Cleaning *...\n"
+	@rm -rf $(ELCS) $(PKG)-autoloads.el *.o *.so
+
 
 ffi-module.so: ffi-module.o
 	$(CC) $(LDFLAGS) -o ffi-module.so ffi-module.o $(LIBS)
 
 ffi-module.o: ffi-module.c
 
-check: ffi-module.so test.so
-	LD_LIBRARY_PATH=`pwd`:$$LD_LIBRARY_PATH; \
-	  export LD_LIBRARY_PATH; \
-	$(GDB) $(EMACS_BUILDDIR)/src/emacs -batch -L `pwd` -l ert -l test.el \
-	  -f ert-run-tests-batch-and-exit
-
-test-module: test.so
-
 test.so: test.o
 	$(CC) $(LDFLAGS) -o test.so test.o
 
-test.o: test.c
+test.o: test.c ffi-module.c
 
-clean:
-	-rm -f ffi.elc ffi-autoloads.el ffi-module.o ffi-module.so
-	-rm -f test.o test.so
+loaddefs: $(PKG)-autoloads.el
+
+%.elc: %.el
+	@printf "Compiling $<\n"
+	@$(EMACS) -Q --batch $(EMACS_ARGS) $(LOAD_PATH) -f batch-byte-compile $<
+
+$(PKG)-autoloads.el: $(ELS)
+	@printf " Creating $@\n"
+	@$(EMACS) -Q --batch -l autoload -l cl-lib --eval "\
+(let ((file (expand-file-name \"$@\"))\
+      (autoload-timestamps nil) \
+      (backup-inhibited t)\
+      (version-control 'never)\
+      (coding-system-for-write 'utf-8-emacs-unix))\
+  (write-region (autoload-rubric file \"package\" nil) nil file nil 'silent)\
+  (cl-letf (((symbol-function 'progress-reporter-do-update) (lambda (&rest _)))\
+            ((symbol-function 'progress-reporter-done) (lambda (_))))\
+    (let ((generated-autoload-file file))\
+      (update-directory-autoloads default-directory))))" \
+	2>&1 | sed "/^Package autoload is deprecated$$/d"

--- a/Makefile
+++ b/Makefile
@@ -43,4 +43,5 @@ test.so: test.o
 test.o: test.c
 
 clean:
-	-rm -f ffi-module.o ffi-module.so test.o test.so
+	-rm -f ffi.elc ffi-autoloads.el ffi-module.o ffi-module.so
+	-rm -f test.o test.so

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ EMACS_BUILDDIR = /home/tromey/Emacs/emacs
 
 LDFLAGS = -shared
 LIBS = -lffi -lltdl
-CFLAGS += -g3 -Og -finline-small-functions -shared -fPIC -I$(EMACS_BUILDDIR)/src/ -I$(EMACS_BUILDDIR)/lib/
+CFLAGS += -g3 -Og -finline-small-functions -shared -fPIC \
+  -I$(EMACS_BUILDDIR)/src/ -I$(EMACS_BUILDDIR)/lib/
 
 # Set this to debug make check.
 #GDB = gdb --args
@@ -32,7 +33,7 @@ ffi-module.o: ffi-module.c
 
 check: ffi-module.so test.so
 	LD_LIBRARY_PATH=`pwd`:$$LD_LIBRARY_PATH; \
-	export LD_LIBRARY_PATH; \
+	  export LD_LIBRARY_PATH; \
 	$(GDB) $(EMACS_BUILDDIR)/src/emacs -batch -L `pwd` -l ert -l test.el \
 	  -f ert-run-tests-batch-and-exit
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,9 @@ CFLAGS += -g3 -Og -finline-small-functions -shared -fPIC \
 # Set this to debug make check.
 #GDB = gdb --args
 
-all: ffi-module.so
+all: module test-module
+
+module: ffi-module.so
 
 ffi-module.so: ffi-module.o
 	$(CC) $(LDFLAGS) -o ffi-module.so ffi-module.o $(LIBS)
@@ -38,6 +40,8 @@ check: ffi-module.so test.so
 	  export LD_LIBRARY_PATH; \
 	$(GDB) $(EMACS_BUILDDIR)/src/emacs -batch -L `pwd` -l ert -l test.el \
 	  -f ert-run-tests-batch-and-exit
+
+test-module: test.so
 
 test.so: test.o
 	$(CC) $(LDFLAGS) -o test.so test.o

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this.  If not, see <https://www.gnu.org/licenses/>.
 
+-include config.mk
+
 # Where your dynamic-module-enabled Emacs build lies.
-EMACS_BUILDDIR = /home/tromey/Emacs/emacs
+EMACS_BUILDDIR ?= /home/tromey/Emacs/emacs
 
 LDFLAGS = -shared
 LIBS = -lffi -lltdl

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 This is an FFI for Emacs.  It is based on libffi and relies on the
-dynamic modules work (available on the Emacs 25 branch) in order to be
-loaded into Emacs.  It is relatively full-featured, but for the time
-being low-level.
+dynamic module support in order to be loaded into Emacs.  It is
+relatively full-featured, but for the time being low-level.
 
 I'd appreciate your feedback, either via email or issues on github.
 

--- a/ffi-module.c
+++ b/ffi-module.c
@@ -19,6 +19,7 @@ along with this.  If not, see <https://www.gnu.org/licenses/>.  */
 #include <ltdl.h>
 #include <string.h>
 #include <assert.h>
+#include <stdbool.h>
 
 // Emacs got rid of this typedef, but it is still handy.
 typedef void (*emacs_finalizer_function) (void *);
@@ -1003,6 +1004,8 @@ init_type_alias (const char *name, bool is_unsigned, int size)
     type_descriptors[i].type = type;
 }
 
+static bool initialized = false;
+
 #define INIT_TYPE_ALIAS(Type)					\
   do								\
     {								\
@@ -1014,6 +1017,9 @@ init_type_alias (const char *name, bool is_unsigned, int size)
 int
 emacs_module_init (struct emacs_runtime *runtime)
 {
+  if (initialized)
+    return 0;
+
   unsigned int i;
   emacs_env *env = runtime->get_environment (runtime);
 
@@ -1063,5 +1069,6 @@ emacs_module_init (struct emacs_runtime *runtime)
 	return -1;
     }
 
+  initialized = true;
   return 0;
 }

--- a/ffi-module.c
+++ b/ffi-module.c
@@ -13,6 +13,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this.  If not, see <https://www.gnu.org/licenses/>.  */
 
+#include <config.h>
 #include "emacs-module.h"
 
 #include <ffi.h>

--- a/ffi-module.c
+++ b/ffi-module.c
@@ -366,7 +366,7 @@ convert_from_lisp (emacs_env *env, ffi_type *type, emacs_value ev,
       // raw pointer.
       if (env->non_local_exit_check (env))
 	return false;
- 
+
       emacs_finalizer_function finalizer = env->get_user_finalizer (env, ev);
       if (env->non_local_exit_check (env))
 	return false;

--- a/ffi.el
+++ b/ffi.el
@@ -43,17 +43,18 @@
   (declare (indent defun))
   ;; Turn variable references into actual types; while keeping keywords
   ;; the same.
-  (let* ((arg-names (mapcar (lambda (_) (cl-gensym)) arg-types))
+  (let* ((n 0)
+         (args (mapcar (lambda (_) (intern (format "arg%d" (cl-incf n)))) arg-types))
          (arg-types (vconcat (mapcar #'symbol-value arg-types)))
          (sym (intern (concat "ffi-fun-" c-name)))
          (cif (ffi--prep-cif (symbol-value return-type) arg-types)))
     `(progn
        (defvar ,sym nil)
-       (defun ,name (,@arg-names)
+       (defun ,name (,@args)
          (unless ,sym
            (setq ,sym (ffi--dlsym ,c-name (,library))))
          ;; FIXME do we even need a separate prep?
-         (ffi--call ,cif ,sym ,@arg-names)))))
+         (ffi--call ,cif ,sym ,@args)))))
 
 (defun ffi-lambda (function-pointer return-type arg-types)
   (let ((cif (ffi--prep-cif return-type (vconcat arg-types))))

--- a/ffi.el
+++ b/ffi.el
@@ -76,32 +76,28 @@
 
 (defun ffi--struct-union-helper (name slots definer-function layout-function)
   (cl-assert (symbolp name))
-  (let* ((docstring (if (stringp (car slots))
-                        (pop slots)))
-         (conc-name (concat (symbol-name name) "-"))
-         (result-forms ())
+  (let* ((docstring (and (stringp (car slots))
+                         (pop slots)))
          (field-types (mapcar (lambda (slot)
                                 (cl-assert (eq (cadr slot) :type))
                                 (symbol-value (cl-caddr slot)))
                               slots))
          (field-offsets (funcall layout-function field-types)))
-    (push `(defvar ,name (apply #',definer-function ',field-types)
-             ,docstring)
-          result-forms)
-    (cl-mapc
-     (lambda (slot type offset)
-       (let ((getter-name (intern (concat conc-name
-                                          (symbol-name (car slot)))))
-             (offsetter (if (> offset 0)
-                            `(ffi-pointer+ object ,offset)
-                          'object)))
-         ;; One benefit of using defsubst here is that we don't have
-         ;; to provide a GV setter.
-         (push `(cl-defsubst ,getter-name (object)
-                  (ffi--mem-ref ,offsetter ,type))
-               result-forms)))
-     slots field-types field-offsets)
-    (cons 'progn (nreverse result-forms))))
+    `(progn
+       (defvar ,name
+         (apply #',definer-function ',field-types)
+         ,docstring)
+       ,@(cl-mapcar
+          (lambda (slot type offset)
+            (let ((getter-name (intern (format "%s-%s" name (car slot))))
+                  (offsetter (if (> offset 0)
+                                 `(ffi-pointer+ object ,offset)
+                               'object)))
+              ;; One benefit of using cl-defsubst here is that we don't
+              ;; have to provide a GV setter.
+              `(cl-defsubst ,getter-name (object)
+                 (ffi--mem-ref ,offsetter ,type))))
+          slots field-types field-offsets))))
 
 (defmacro define-ffi-struct (name &rest slots)
   "Like a limited form of `cl-defstruct', but works with foreign objects.

--- a/ffi.el
+++ b/ffi.el
@@ -41,11 +41,10 @@
 
 (defmacro define-ffi-function (name c-name return-type arg-types library)
   (declare (indent defun))
-  (let* (;; Turn variable references into actual types; while keeping
-         ;; keywords the same.
-         (arg-types (mapcar #'symbol-value arg-types))
-         (arg-names (mapcar (lambda (_ignore) (cl-gensym)) arg-types))
-         (arg-types (vconcat arg-types))
+  ;; Turn variable references into actual types; while keeping keywords
+  ;; the same.
+  (let* ((arg-names (mapcar (lambda (_) (cl-gensym)) arg-types))
+         (arg-types (vconcat (mapcar #'symbol-value arg-types)))
          (sym (intern (concat "ffi-fun-" c-name)))
          (cif (ffi--prep-cif (symbol-value return-type) arg-types)))
     `(progn

--- a/ffi.el
+++ b/ffi.el
@@ -28,7 +28,7 @@
 
 (require 'cl-macs)
 
-(eval-and-compile (module-load "ffi-module.so"))
+(eval-and-compile (module-load (locate-library "ffi-module")))
 
 (gv-define-simple-setter ffi--mem-ref ffi--mem-set t)
 
@@ -37,7 +37,7 @@
     (set library nil)
     `(defun ,symbol ()
        (or ,library
-           (setq ,library (ffi--dlopen ,name))))))
+           (setq ,library (ffi--dlopen (locate-library ,name)))))))
 
 (defmacro define-ffi-function (name c-name return-type arg-types library)
   (declare (indent defun))

--- a/ffi.el
+++ b/ffi.el
@@ -52,8 +52,9 @@
          (unless ,sym
            (setq ,sym (ffi--dlsym ,c-name (,library))))
          ;; FIXME do we even need a separate prep?
-         (ffi--call (ffi--prep-cif (symbol-value ,return-type)
-                                   ,(vconcat (mapcar #'symbol-value arg-types)))
+         (ffi--call (ffi--prep-cif ,return-type
+                                   (vconcat
+                                    (mapcar #'symbol-value ',arg-types)))
                     ,sym ,@args)))))
 
 (defun ffi-lambda (function-pointer return-type arg-types)

--- a/ffi.el
+++ b/ffi.el
@@ -66,12 +66,10 @@
 
 (defun ffi--lay-out-struct (types)
   (let ((offset 0))
-    (mapcar (lambda (this-type)
-              (setf offset (ffi--align offset
-                                       (ffi--type-alignment this-type)))
-              (let ((here offset))
-                (cl-incf offset (ffi--type-size this-type))
-                here))
+    (mapcar (lambda (type)
+              (prog1
+                  (setq offset (ffi--align offset (ffi--type-alignment type)))
+                (cl-incf offset (ffi--type-size type))))
             types)))
 
 (defun ffi--struct-union-helper (name slots definer-function layout-function)

--- a/ffi.el
+++ b/ffi.el
@@ -28,7 +28,7 @@
 
 (require 'cl-macs)
 
-(module-load "ffi-module.so")
+(eval-and-compile (module-load "ffi-module.so"))
 
 (gv-define-simple-setter ffi--mem-ref ffi--mem-set t)
 

--- a/ffi.el
+++ b/ffi.el
@@ -40,6 +40,7 @@
            (setq ,library (ffi--dlopen ,name))))))
 
 (defmacro define-ffi-function (name c-name return-type arg-types library)
+  (declare (indent defun))
   (let* (;; Turn variable references into actual types; while keeping
          ;; keywords the same.
          (arg-types (mapcar #'symbol-value arg-types))
@@ -107,6 +108,7 @@
 NAME must be a symbol.
 Each SLOT must be of the form `(SLOT-NAME :type TYPE)', where
 SLOT-NAME is a symbol and TYPE is an FFI type descriptor."
+  (declare (indent defun))
   (ffi--struct-union-helper name slots #'ffi--define-struct
                             #'ffi--lay-out-struct))
 
@@ -116,12 +118,14 @@ SLOT-NAME is a symbol and TYPE is an FFI type descriptor."
 NAME must be a symbol.
 Each SLOT must be of the form `(SLOT-NAME :type TYPE)', where
 SLOT-NAME is a symbol and TYPE is an FFI type descriptor."
+  (declare (indent defun))
   (ffi--struct-union-helper name slots #'ffi--define-union
                             (lambda (types)
                               (make-list (length types) 0))))
 
 (defmacro define-ffi-array (name type length &optional docstring)
   ;; This is a hack until libffi gives us direct support.
+  (declare (indent defun))
   (let ((type-description
          (apply #'ffi--define-struct
                 (make-list (eval length) (symbol-value type)))))

--- a/ffi.el
+++ b/ffi.el
@@ -37,26 +37,26 @@
     (set library nil)
     `(defun ,symbol ()
        (or ,library
-	   (setq ,library (ffi--dlopen ,name))))))
+           (setq ,library (ffi--dlopen ,name))))))
 
 (defmacro define-ffi-function (name c-name return-type arg-types library)
   (let* (;; Turn variable references into actual types; while keeping
-	 ;; keywords the same.
-	 (arg-types (mapcar #'symbol-value arg-types))
-	 (arg-names (mapcar (lambda (_ignore) (cl-gensym)) arg-types))
-	 (arg-types (vconcat arg-types))
-	 (function (cl-gensym))
-	 (cif (ffi--prep-cif (symbol-value return-type) arg-types)))
+         ;; keywords the same.
+         (arg-types (mapcar #'symbol-value arg-types))
+         (arg-names (mapcar (lambda (_ignore) (cl-gensym)) arg-types))
+         (arg-types (vconcat arg-types))
+         (function (cl-gensym))
+         (cif (ffi--prep-cif (symbol-value return-type) arg-types)))
     (set function nil)
     `(defun ,name (,@arg-names)
        (unless ,function
-	 (setq ,function (ffi--dlsym ,c-name (,library))))
+         (setq ,function (ffi--dlsym ,c-name (,library))))
        ;; FIXME do we even need a separate prep?
        (ffi--call ,cif ,function ,@arg-names))))
 
 (defun ffi-lambda (function-pointer return-type arg-types)
   (let ((cif (ffi--prep-cif return-type (vconcat arg-types))))
-    (lambda (&rest args)		; lame
+    (lambda (&rest args)             ; lame
       (apply #'ffi--call cif function-pointer args))))
 
 (defsubst ffi--align (offset align)
@@ -65,39 +65,39 @@
 (defun ffi--lay-out-struct (types)
   (let ((offset 0))
     (mapcar (lambda (this-type)
-	      (setf offset (ffi--align offset
-				       (ffi--type-alignment this-type)))
-	      (let ((here offset))
-		(cl-incf offset (ffi--type-size this-type))
-		here))
-	    types)))
+              (setf offset (ffi--align offset
+                                       (ffi--type-alignment this-type)))
+              (let ((here offset))
+                (cl-incf offset (ffi--type-size this-type))
+                here))
+            types)))
 
 (defun ffi--struct-union-helper (name slots definer-function layout-function)
   (cl-assert (symbolp name))
   (let* ((docstring (if (stringp (car slots))
-			(pop slots)))
-	 (conc-name (concat (symbol-name name) "-"))
-	 (result-forms ())
-	 (field-types (mapcar (lambda (slot)
-				(cl-assert (eq (cadr slot) :type))
-				(symbol-value (cl-caddr slot)))
-			      slots))
-	 (the-type (apply definer-function field-types))
-	 (field-offsets (funcall layout-function field-types)))
+                        (pop slots)))
+         (conc-name (concat (symbol-name name) "-"))
+         (result-forms ())
+         (field-types (mapcar (lambda (slot)
+                                (cl-assert (eq (cadr slot) :type))
+                                (symbol-value (cl-caddr slot)))
+                              slots))
+         (the-type (apply definer-function field-types))
+         (field-offsets (funcall layout-function field-types)))
     (push `(defvar ,name ,the-type ,docstring)
-	  result-forms)
+          result-forms)
     (cl-mapc
      (lambda (slot type offset)
        (let ((getter-name (intern (concat conc-name
-					  (symbol-name (car slot)))))
-	     (offsetter (if (> offset 0)
-			    `(ffi-pointer+ object ,offset)
-			  'object)))
-	 ;; One benefit of using defsubst here is that we don't have
-	 ;; to provide a GV setter.
-	 (push `(cl-defsubst ,getter-name (object)
-		  (ffi--mem-ref ,offsetter ,type))
-	       result-forms)))
+                                          (symbol-name (car slot)))))
+             (offsetter (if (> offset 0)
+                            `(ffi-pointer+ object ,offset)
+                          'object)))
+         ;; One benefit of using defsubst here is that we don't have
+         ;; to provide a GV setter.
+         (push `(cl-defsubst ,getter-name (object)
+                  (ffi--mem-ref ,offsetter ,type))
+               result-forms)))
      slots field-types field-offsets)
     (cons 'progn (nreverse result-forms))))
 
@@ -108,7 +108,7 @@ NAME must be a symbol.
 Each SLOT must be of the form `(SLOT-NAME :type TYPE)', where
 SLOT-NAME is a symbol and TYPE is an FFI type descriptor."
   (ffi--struct-union-helper name slots #'ffi--define-struct
-			    #'ffi--lay-out-struct))
+                            #'ffi--lay-out-struct))
 
 (defmacro define-ffi-union (name &rest slots)
   "Like a limited form of `cl-defstruct', but works with foreign objects.
@@ -117,13 +117,13 @@ NAME must be a symbol.
 Each SLOT must be of the form `(SLOT-NAME :type TYPE)', where
 SLOT-NAME is a symbol and TYPE is an FFI type descriptor."
   (ffi--struct-union-helper name slots #'ffi--define-union
-			    (lambda (types)
-			      (make-list (length types) 0))))
+                            (lambda (types)
+                              (make-list (length types) 0))))
 
 (defmacro define-ffi-array (name type length &optional docstring)
   ;; This is a hack until libffi gives us direct support.
   (let ((type-description
-	 (apply #'ffi--define-struct
+         (apply #'ffi--define-struct
                 (make-list (eval length) (symbol-value type)))))
     `(defvar ,name ,type-description ,docstring)))
 
@@ -140,11 +140,11 @@ SLOT-NAME is a symbol and TYPE is an FFI type descriptor."
 (defmacro with-ffi-temporaries (bindings &rest body)
   (declare (indent defun))
   (let ((first-binding (car bindings))
-	(rest-bindings (cdr bindings)))
+        (rest-bindings (cdr bindings)))
     (if rest-bindings
-	`(with-ffi-temporary ,first-binding
-	   (with-ffi-temporaries ,rest-bindings
-	     ,@body))
+        `(with-ffi-temporary ,first-binding
+           (with-ffi-temporaries ,rest-bindings
+             ,@body))
       `(with-ffi-temporary ,first-binding ,@body))))
 
 (defmacro with-ffi-string (binding &rest body)
@@ -157,11 +157,11 @@ SLOT-NAME is a symbol and TYPE is an FFI type descriptor."
 (defmacro with-ffi-strings (bindings &rest body)
   (declare (indent defun))
   (let ((first-binding (car bindings))
-	(rest-bindings (cdr bindings)))
+        (rest-bindings (cdr bindings)))
     (if rest-bindings
-	`(with-ffi-string ,first-binding
-	   (with-ffi-strings ,rest-bindings
-	     ,@body))
+        `(with-ffi-string ,first-binding
+           (with-ffi-strings ,rest-bindings
+             ,@body))
       `(with-ffi-string ,first-binding ,@body))))
 
 (provide 'ffi)

--- a/ffi.el
+++ b/ffi.el
@@ -1,5 +1,10 @@
 ;;; ffi.el --- FFI for Emacs  -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2015-2017 Tom Tromey
+
+;; Author: Tom Tromey <tom@tromey.com>
+;; Package-Requires: ((emacs "25.1"))
+
 ;; This is is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
@@ -12,6 +17,14 @@
 
 ;; You should have received a copy of the GNU General Public License
 ;; along with this.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This is an FFI for Emacs.  It is based on libffi and relies on the
+;; dynamic module support in order to be loaded into Emacs.  It is
+;; relatively full-featured, but for the time being low-level.
+
+;;; Code:
 
 (require 'cl-macs)
 

--- a/ffi.el
+++ b/ffi.el
@@ -27,8 +27,7 @@
 	   (setq ,library (ffi--dlopen ,name))))))
 
 (defmacro define-ffi-function (name c-name return-type arg-types library)
-  (let* (
-	 ;; Turn variable references into actual types; while keeping
+  (let* (;; Turn variable references into actual types; while keeping
 	 ;; keywords the same.
 	 (arg-types (mapcar #'symbol-value arg-types))
 	 (arg-names (mapcar (lambda (_ignore) (cl-gensym)) arg-types))

--- a/ffi.el
+++ b/ffi.el
@@ -55,7 +55,7 @@
        (ffi--call ,cif ,function ,@arg-names))))
 
 (defun ffi-lambda (function-pointer return-type arg-types)
-  (let* ((cif (ffi--prep-cif return-type (vconcat arg-types))))
+  (let ((cif (ffi--prep-cif return-type (vconcat arg-types))))
     (lambda (&rest args)		; lame
       (apply #'ffi--call cif function-pointer args))))
 

--- a/test.el
+++ b/test.el
@@ -18,16 +18,16 @@
 (require 'ert)
 (require 'ffi)
 
-(define-ffi-library test.so "test")
+(define-ffi-library ffi-test "test")
 
-(define-ffi-function test-function "test_function" :int nil test.so)
-(define-ffi-function test-function-char "test_function" :char nil test.so)
+(define-ffi-function test-function "test_function" :int nil ffi-test)
+(define-ffi-function test-function-char "test_function" :char nil ffi-test)
 
 (ert-deftest ffi-basic ()
   (should (= (test-function) 27))
   (should (= (test-function-char) 27)))
 
-(define-ffi-function test-c-string "test_c_string" :pointer nil test.so)
+(define-ffi-function test-c-string "test_c_string" :pointer nil ffi-test)
 
 (ert-deftest ffi-pointer-type ()
   (should (eq (type-of (test-c-string)) 'user-ptr)))
@@ -39,14 +39,14 @@
   (1+ arg))
 
 (define-ffi-function test-call-callback "test_call_callback"
-  :int [:pointer] test.so)
+  :int [:pointer] ffi-test)
 
 (ert-deftest ffi-call-callback ()
   (let* ((cif (ffi--prep-cif :int [:int]))
          (pointer-to-callback (ffi-make-closure cif #'callback)))
     (should (eq (test-call-callback pointer-to-callback) 23))))
 
-(define-ffi-function test-add "test_add" :int [:int :int] test.so)
+(define-ffi-function test-add "test_add" :int [:int :int] ffi-test)
 
 (ert-deftest ffi-add ()
   (should (eq (test-add 23 -23) 0)))
@@ -75,7 +75,7 @@
   (intval :type :int))
 
 (define-ffi-function test-get-struct "test_get_struct"
-  test-struct nil test.so)
+  test-struct nil ffi-test)
 
 (ert-deftest ffi-structure-return ()
   (let ((struct-value (test-get-struct)))
@@ -84,7 +84,7 @@
     (should (eq (test-struct-intval struct-value) 23))))
 
 (define-ffi-function test-get-struct-int "test_get_struct_int"
-  :int (test-struct) test.so)
+  :int (test-struct) ffi-test)
 
 (ert-deftest ffi-struct-modification ()
   (let ((struct-value (test-get-struct)))
@@ -97,7 +97,7 @@
   (ival :type :int))
 
 (define-ffi-function test-get-union "test_get_union"
-  test-union nil test.so)
+  test-union nil ffi-test)
 
 (ert-deftest ffi-union ()
   (let ((object (test-get-union)))
@@ -107,7 +107,8 @@
 (ert-deftest ffi-null ()
   (should (ffi-pointer-null-p (ffi-null-pointer))))
 
-(define-ffi-function test-not "test_not" :bool (:bool) test.so)
+(define-ffi-function test-not "test_not"
+  :bool (:bool) ffi-test)
 
 (ert-deftest ffi-boolean ()
   (should (eq (test-not nil) t))
@@ -118,8 +119,8 @@
 (defconst test-user-defined-char :char)
 
 (ert-deftest ffi-array ()
-  (should (eq (define-ffi-array arr1 :char 1024) 'arr1))
-  (should (eq (define-ffi-array arr2 test-user-defined-char 1024) 'arr2)))
+  (should (eq (define-ffi-array test-arr1 :char 1024) 'test-arr1))
+  (should (eq (define-ffi-array test-arr2 test-user-defined-char 1024) 'test-arr2)))
 
 (ert-deftest ffi-with-ffi-multi-stat ()
   (should (eq (with-ffi-temporary (a :int) 1 2 3) 3))

--- a/test.el
+++ b/test.el
@@ -1,4 +1,4 @@
-;;; test.el --- FFI tests for Emacs
+;;; test.el --- FFI tests for Emacs  -*- lexical-binding: t; -*-
 
 ;; This is is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -56,14 +56,14 @@
                 (ffi--type-alignment :int)))))
 
 (ert-deftest ffi-struct-layout-offsets ()
-  (let* ((types '(:pointer :int))
-         (struct-type (apply #'ffi--define-struct types)))
+  (let ((types '(:pointer :int)))
+    (apply #'ffi--define-struct types)
     (should (equal (ffi--lay-out-struct types)
                    (list 0 (ffi--type-size :pointer))))))
 
 (ert-deftest ffi-struct-layout-offsets-2 ()
-  (let* ((types '(:char :pointer))
-         (struct-type (apply #'ffi--define-struct types)))
+  (let ((types '(:char :pointer)))
+    (apply #'ffi--define-struct types)
     (should (equal (ffi--lay-out-struct types)
                    (list 0 (ffi--type-alignment :pointer))))))
 

--- a/test.el
+++ b/test.el
@@ -13,6 +13,9 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this.  If not, see <https://www.gnu.org/licenses/>.
 
+;;; Code:
+
+(require 'ert)
 (require 'ffi)
 
 (define-ffi-library test.so "test")

--- a/test.el
+++ b/test.el
@@ -54,7 +54,7 @@
 		(ffi--type-size :int)))
     (should (eq (ffi--type-alignment struct-type)
 		(ffi--type-alignment :int)))))
-    
+
 (ert-deftest ffi-struct-layout-offsets ()
   (let* ((types '(:pointer :int))
 	 (struct-type (apply #'ffi--define-struct types)))

--- a/test.el
+++ b/test.el
@@ -40,7 +40,7 @@
 
 (ert-deftest ffi-call-callback ()
   (let* ((cif (ffi--prep-cif :int [:int]))
-	 (pointer-to-callback (ffi-make-closure cif #'callback)))
+         (pointer-to-callback (ffi-make-closure cif #'callback)))
     (should (eq (test-call-callback pointer-to-callback) 23))))
 
 (define-ffi-function test-add "test_add" :int [:int :int] test.so)
@@ -51,21 +51,21 @@
 (ert-deftest ffi-struct-layout ()
   (let ((struct-type (ffi--define-struct :int)))
     (should (eq (ffi--type-size struct-type)
-		(ffi--type-size :int)))
+                (ffi--type-size :int)))
     (should (eq (ffi--type-alignment struct-type)
-		(ffi--type-alignment :int)))))
+                (ffi--type-alignment :int)))))
 
 (ert-deftest ffi-struct-layout-offsets ()
   (let* ((types '(:pointer :int))
-	 (struct-type (apply #'ffi--define-struct types)))
+         (struct-type (apply #'ffi--define-struct types)))
     (should (equal (ffi--lay-out-struct types)
-		   (list 0 (ffi--type-size :pointer))))))
+                   (list 0 (ffi--type-size :pointer))))))
 
 (ert-deftest ffi-struct-layout-offsets-2 ()
   (let* ((types '(:char :pointer))
-	 (struct-type (apply #'ffi--define-struct types)))
+         (struct-type (apply #'ffi--define-struct types)))
     (should (equal (ffi--lay-out-struct types)
-		   (list 0 (ffi--type-alignment :pointer))))))
+                   (list 0 (ffi--type-alignment :pointer))))))
 
 (define-ffi-struct test-struct
   (stringval :type :pointer)
@@ -77,7 +77,7 @@
 (ert-deftest ffi-structure-return ()
   (let ((struct-value (test-get-struct)))
     (should (equal (ffi-get-c-string (test-struct-stringval struct-value))
-		   "string"))
+                   "string"))
     (should (eq (test-struct-intval struct-value) 23))))
 
 (define-ffi-function test-get-struct-int "test_get_struct_int"


### PR DESCRIPTION
Hi Tom, it was great talking to you at FOSDEM.  I have finally gotten around to playing with this ffi and I'm liking it a lot but I immediately ran into issues.

I think it has a lot of potential but also needs some work to fulfill its potential.  Even though this has been sitting around mostly unused for five years now, I hope that you are soon going to put in some more work to make it more usable.  It seems to me that the hard parts are done but that the polish is lacking.

I would like to help with that effort starting with this pull-request.  It comes with assorted cleanup, but the main improvements concern how libraries are located.  That is done in the last three commits.

It's probably not a good idea in the long run to re-purpose `load-path` for C libraries as well but at least it is a step up from forcing users to place C libraries inside this repository or to bind `default-directory` around code that might load a library. Maybe something like `ffi-library-path` should be added.

The module support in Emacs has the same issue more or less; here too it is not really specified how one should located a library.  As far as I can tell something like `module-path` exists.

I would like to see this added to Melpa rather sooner than later and I can help with that (I am a deputy maintainer).  But you would also have to put in more work of course.  I think it is worth it though.

This ffi could help with adaption of the dynamic module functionality a lot, even if it is only used for prototyping.  But that of course assumes that it is easy to get started.  We are not there yet but with more documentation and fewer sharp edges this could be quite successful.

We would also have to think about how a `ffi.el` that has been installed from Melpa would build `ffi-module.c` and how to communicate to the user that they have to install `libffi`.  There are a few modules in Melpa, but I don't think a common pattern has emerged yet how this sort of thing should be handled.  Eventually packages will appear on Melpa that use *this* package to interface with C, and we should avoid the same situation where everyone has to reinvent the wheel and should instead come up with best practices beforehand and document them.

So yeah, it will be a bit of work, but still: What do you think?

Ps: Please start by adding a LICENSE file and adding the permission statement to `ffi.el`.